### PR TITLE
:wrench: Docker-Configuration extended for new deployment unit

### DIFF
--- a/digiwf-gateway/src/main/resources/application-docker.yml
+++ b/digiwf-gateway/src/main/resources/application-docker.yml
@@ -28,6 +28,11 @@ spring:
           predicates:
             - Path=/camunda/**
 
+        - id: webcomponent-dockerized
+          uri: http://digiwf-webcomponent:8080/
+          predicates:
+            - Path=/webcomponent/**
+
         - id: frontend-dockerized
           uri: http://digiwf-tasklist:8080/
           predicates:

--- a/digiwf-gateway/src/main/resources/application-local.yml
+++ b/digiwf-gateway/src/main/resources/application-local.yml
@@ -54,6 +54,11 @@ spring:
           predicates:
             - Path=/app/**
 
+        - id: webcomponent
+          uri: http://localhost:8085/
+          predicates:
+            - Path=/webcomponent/**
+
       default-filters:
         - RemoveResponseHeader=Expires
 #        - RemoveRequestHeader=cookie

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -138,6 +138,15 @@ services:
       - tasklist-frontend
     networks:
       - internal
+
+  digiwf-webcomponent:
+    image: itatm/digiwf-webcomponent:dev
+    ports:
+      - "8092:8080"
+    profiles:
+      - webcomponent
+    networks:
+      - internal
   #
   # Local keycloak. To work properly, you need to change your local hosts file and add an alias to your
   # `127.0.0.1 localhost` line to look like this: `127.0.0.1 localhost keycloak`.


### PR DESCRIPTION
### Description

- Spring-Konfiguration für zusätzliche Profile hinzugefügt
- Docker-Compose angepasst um WebComponent-Image per Profil als Container starten zu können

### Reference

Issues: closes #14 
